### PR TITLE
Added Adobe repository in order to complete install

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,13 @@
 			<distribution>repo</distribution>
 		</license>
 	</licenses>
+    
+    <repositories>
+		<repository>
+			<id>adobe-repo</id>
+			<url>http://repo.adobe.com/nexus/content/groups/public</url>
+		</repository>
+	</repositories>
 
 	<scm>
 		<connection>scm:git:git@github.com:Citytechinc/cq5-groovy-console.git</connection>


### PR DESCRIPTION
This will get the cq5 dependencies as the mvn build fails without them.
