### PR TITLE
POM fix - 0.7.1 version of the extension project

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -384,7 +384,7 @@
         <dependency>
             <groupId>com.citytechinc.aem.groovy.extension</groupId>
             <artifactId>aem-groovy-extension-bundle</artifactId>
-            <version>0.6.2</version>
+            <version>0.7.1</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
I've updated version of aem-groovy-extension-bundle in console project's POM.

Could you please release the 6.1.1 version with it?
Also, since the console project now contains the extension API, it might be worth pushing that version to 
Citytech's public Nexus repository.
