### PR TITLE
Added missing clientlib so that the console works on publish.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>cq-groovy-console</artifactId>
     <packaging>jar</packaging>
-    <version>6.1.1</version>
+    <version>6.1.2-SNAPSHOT</version>
     <name>CQ Groovy Console</name>
     <description>
         The CQ Groovy Console provides an interface for running Groovy scripts in the Adobe CQ container. Scripts

--- a/src/main/content/jcr_root/apps/groovyconsole/components/console/head.jsp
+++ b/src/main/content/jcr_root/apps/groovyconsole/components/console/head.jsp
@@ -8,5 +8,6 @@
         <cq:includeClientLib categories="cq.wcm.edit" />
     </c:if>
 
+	<cq:includeClientLib categories="cq.shared" />
 	<cq:includeClientLib categories="groovyconsole" />
 </head>


### PR DESCRIPTION
This clientlib is automatically included on author instances, however it is not included on publish instances and thus throws an error on the JS line modified as a result of https://github.com/Citytechinc/cq-groovy-console/issues/9.

This fix adds the inclusion of the "cq.shared" clientlib.
