### PR TITLE
Add cq.shared dependency to clientlib

### DIFF
--- a/src/main/content/jcr_root/etc/groovyconsole/clientlibs/.content.xml
+++ b/src/main/content/jcr_root/etc/groovyconsole/clientlibs/.content.xml
@@ -4,4 +4,5 @@
           xmlns:jcr="http://www.jcp.org/jcr/1.0"
           jcr:primaryType="cq:ClientLibraryFolder"
           sling:resourceType="widgets/clientlib"
-          categories="[groovyconsole]" />
+          categories="[groovyconsole]"
+          dependencies="[cq.shared]"/>


### PR DESCRIPTION
This allows the console to be used on publishers and in disabled mode.
