### PR TITLE
Fix a bug introduced with #90

### DIFF
--- a/src/main/groovy/com/icfolson/aem/groovy/console/configuration/impl/DefaultConfigurationService.groovy
+++ b/src/main/groovy/com/icfolson/aem/groovy/console/configuration/impl/DefaultConfigurationService.groovy
@@ -49,7 +49,7 @@ class DefaultConfigurationService implements ConfigurationService {
 
             LOG.debug("member of group IDs = {}, allowed group IDs = {}", memberOfGroupIds, allowedGroups)
 
-            hasPermission = allowedGroups ? user.admin || memberOfGroupIds.intersect(allowedGroups as Iterable) : false
+            hasPermission = user.admin || (allowedGroups ? memberOfGroupIds.intersect(allowedGroups as Iterable) : false)
         } finally {
             resourceResolver.close()
         }


### PR DESCRIPTION
The change introduced in #88, always allowing the admin user to run scripts, had a slight logical error, that was exposed when #90 was added.

Closes #98 